### PR TITLE
NodeInfo 2.0

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,4 +1,4 @@
-# NodeInfo protocol 1.1
+# NodeInfo protocol 2.0
 
 ## Definitions
 
@@ -23,6 +23,8 @@ Currently the following relations are known:
   following the NodeInfo schema 1.0.
 * `http://nodeinfo.diaspora.software/ns/schema/1.1`. Referencing a JSON document
   following the NodeInfo schema 1.1.
+* `http://nodeinfo.diaspora.software/ns/schema/2.0`. Referencing a JSON document
+  following the NodeInfo schema 2.0.
 
 A client should first try the HTTPS protocol and fall back to HTTP on
 connection errors or if it can't validate the presented certificate.
@@ -44,15 +46,15 @@ unspecified.
 ### Example
 
 The server at `https://example.org` supporting NodeInfo schema up to version
-1.1 should provide `https://example.org/.well-known/nodeinfo` with the following
+2.0 should provide `https://example.org/.well-known/nodeinfo` with the following
 contents:
 
 ```json
  {
     "links": [
         {
-            "rel": "http://nodeinfo.diaspora.software/ns/schema/1.1",
-            "href": "https://example.org/nodeinfo/1.1"
+            "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0",
+            "href": "https://example.org/nodeinfo/2.0"
         }
     ]
  }
@@ -66,7 +68,7 @@ Accept header to the `application/json` media type.
 
 A server must provide the data at least in this media type. A server should
 set a Content-Type of
-`application/json; profile=http://nodeinfo.diaspora.software/ns/schema/1.1#`,
+`application/json; profile=http://nodeinfo.diaspora.software/ns/schema/2.0#`,
 where the value of profile matches the resolution scope of the NodeInfo
 schema version that's being returned.
 

--- a/schemas/2.0/example.json
+++ b/schemas/2.0/example.json
@@ -4,10 +4,7 @@
     "name": "diaspora",
     "version": "0.5.0"
   },
-  "protocols": {
-    "inbound": ["diaspora"],
-    "outbound": ["diaspora"]
-  },
+  "protocols": ["diaspora"],
   "services": {
     "inbound": ["gnusocial"],
     "outbound": ["facebook", "twitter"]

--- a/schemas/2.0/example.json
+++ b/schemas/2.0/example.json
@@ -1,0 +1,28 @@
+{
+  "version": "2.0",
+  "software": {
+    "name": "diaspora",
+    "version": "0.5.0"
+  },
+  "protocols": {
+    "inbound": ["diaspora"],
+    "outbound": ["diaspora"]
+  },
+  "services": {
+    "inbound": ["gnusocial"],
+    "outbound": ["facebook", "twitter"]
+  },
+  "openRegistrations": true,
+  "usage": {
+    "users": {
+      "total": 123,
+      "activeHalfyear": 42,
+      "activeMonth": 23
+    },
+    "localPosts": 500,
+    "localComments": 1000
+  },
+  "metadata": {
+    "chat_enabled": true
+  }
+}

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -51,7 +51,6 @@
           "dfrn",
           "diaspora",
           "libertree",
-          "mediagoblin",
           "ostatus",
           "pumpio",
           "smtp",

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -105,6 +105,7 @@
           "items": {
             "enum": [
               "gnusocial",
+              "pnut",
               "pumpio"
             ]
           }
@@ -131,6 +132,7 @@
               "mediagoblin",
               "myspace",
               "pinterest",
+              "pnut",
               "posterous",
               "pumpio",
               "redmatrix",

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -46,6 +46,7 @@
       "minItems": 1,
       "items": {
         "enum": [
+          "activitypub",
           "buddycloud",
           "dfrn",
           "diaspora",

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://nodeinfo.diaspora.software/ns/schema/2.0#",
+  "description": "NodeInfo schema version 2.0.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "software",
+    "protocols",
+    "services",
+    "openRegistrations",
+    "usage",
+    "metadata"
+  ],
+  "properties": {
+    "version": {
+      "description": "The schema version, must be 2.0.",
+      "enum": [
+        "2.0"
+      ]
+    },
+    "software": {
+      "description": "Metadata about server software in use.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "description": "The canonical name of this server software.",
+          "enum": [
+            "diaspora",
+            "friendica",
+            "hubzilla",
+            "redmatrix"
+          ]
+        },
+        "version": {
+          "description": "The version of this server software.",
+          "type": "string"
+        }
+      }
+    },
+    "protocols": {
+      "description": "The protocols supported on this server.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inbound",
+        "outbound"
+      ],
+      "properties": {
+        "inbound": {
+          "description": "The protocols this server can receive traffic for.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "buddycloud",
+              "diaspora",
+              "friendica",
+              "gnusocial",
+              "libertree",
+              "mediagoblin",
+              "pumpio",
+              "redmatrix",
+              "smtp",
+              "tent",
+              "zot"
+            ]
+          }
+        },
+        "outbound": {
+          "description": "The protocols this server can generate traffic for.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "buddycloud",
+              "diaspora",
+              "friendica",
+              "gnusocial",
+              "libertree",
+              "mediagoblin",
+              "pumpio",
+              "redmatrix",
+              "smtp",
+              "tent",
+              "zot"
+            ]
+          }
+        }
+      }
+    },
+    "services": {
+      "description": "The third party sites this server can connect to via their application API.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inbound",
+        "outbound"
+      ],
+      "properties": {
+        "inbound": {
+          "description": "The third party sites this server can retrieve messages from for combined display with regular traffic.",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "enum": [
+              "appnet",
+              "gnusocial",
+              "pumpio"
+            ]
+          }
+        },
+        "outbound": {
+          "description": "The third party sites this server can publish messages to on the behalf of a user.",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "enum": [
+              "appnet",
+              "blogger",
+              "buddycloud",
+              "diaspora",
+              "dreamwidth",
+              "drupal",
+              "facebook",
+              "friendica",
+              "gnusocial",
+              "google",
+              "insanejournal",
+              "libertree",
+              "linkedin",
+              "livejournal",
+              "mediagoblin",
+              "myspace",
+              "pinterest",
+              "posterous",
+              "pumpio",
+              "redmatrix",
+              "smtp",
+              "tent",
+              "tumblr",
+              "twitter",
+              "wordpress",
+              "xmpp"
+            ]
+          }
+        }
+      }
+    },
+    "openRegistrations": {
+      "description": "Whether this server allows open self-registration.",
+      "type": "boolean"
+    },
+    "usage": {
+      "description": "Usage statistics for this server.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "description": "statistics about the users of this server.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "total": {
+              "description": "The total amount of on this server registered users.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "activeHalfyear": {
+              "description": "The amount of users that signed in at least once in the last 180 days.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "activeMonth": {
+              "description": "The amount of users that signed in at least once in the last 30 days.",
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "localPosts": {
+          "description": "The amount of posts that were made by users that are registered on this server.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "localComments": {
+          "description": "The amount of comments that were made by users that are registered on this server.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "metadata": {
+      "description": "Free form key value pairs for software specific values. Clients should not rely on any specific key present.",
+      "type": "object",
+      "minProperties": 0,
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -55,6 +55,7 @@
           "pumpio",
           "smtp",
           "tent",
+          "xmpp",
           "zot"
         ]
       }

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -53,7 +53,6 @@
           "libertree",
           "ostatus",
           "pumpio",
-          "smtp",
           "tent",
           "xmpp",
           "zot"

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -56,13 +56,12 @@
           "items": {
             "enum": [
               "buddycloud",
+              "dfrn",
               "diaspora",
-              "friendica",
-              "gnusocial",
               "libertree",
               "mediagoblin",
+              "ostatus",
               "pumpio",
-              "redmatrix",
               "smtp",
               "tent",
               "zot"
@@ -76,13 +75,12 @@
           "items": {
             "enum": [
               "buddycloud",
+              "dfrn",
               "diaspora",
-              "friendica",
-              "gnusocial",
               "libertree",
               "mediagoblin",
+              "ostatus",
               "pumpio",
-              "redmatrix",
               "smtp",
               "tent",
               "zot"

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -31,12 +31,8 @@
       "properties": {
         "name": {
           "description": "The canonical name of this server software.",
-          "enum": [
-            "diaspora",
-            "friendica",
-            "hubzilla",
-            "redmatrix"
-          ]
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
         },
         "version": {
           "description": "The version of this server software.",

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -104,7 +104,6 @@
           "minItems": 0,
           "items": {
             "enum": [
-              "appnet",
               "gnusocial",
               "pumpio"
             ]
@@ -116,7 +115,6 @@
           "minItems": 0,
           "items": {
             "enum": [
-              "appnet",
               "blogger",
               "buddycloud",
               "diaspora",

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -106,7 +106,9 @@
             "enum": [
               "atom1.0",
               "gnusocial",
+              "imap",
               "pnut",
+              "pop3",
               "pumpio",
               "rss2.0",
               "twitter"

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -108,7 +108,8 @@
               "gnusocial",
               "pnut",
               "pumpio",
-              "rss2.0"
+              "rss2.0",
+              "twitter"
             ]
           }
         },

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -42,51 +42,21 @@
     },
     "protocols": {
       "description": "The protocols supported on this server.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "inbound",
-        "outbound"
-      ],
-      "properties": {
-        "inbound": {
-          "description": "The protocols this server can receive traffic for.",
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "enum": [
-              "buddycloud",
-              "dfrn",
-              "diaspora",
-              "libertree",
-              "mediagoblin",
-              "ostatus",
-              "pumpio",
-              "smtp",
-              "tent",
-              "zot"
-            ]
-          }
-        },
-        "outbound": {
-          "description": "The protocols this server can generate traffic for.",
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "enum": [
-              "buddycloud",
-              "dfrn",
-              "diaspora",
-              "libertree",
-              "mediagoblin",
-              "ostatus",
-              "pumpio",
-              "smtp",
-              "tent",
-              "zot"
-            ]
-          }
-        }
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "buddycloud",
+          "dfrn",
+          "diaspora",
+          "libertree",
+          "mediagoblin",
+          "ostatus",
+          "pumpio",
+          "smtp",
+          "tent",
+          "zot"
+        ]
       }
     },
     "services": {

--- a/schemas/2.0/schema.json
+++ b/schemas/2.0/schema.json
@@ -104,9 +104,11 @@
           "minItems": 0,
           "items": {
             "enum": [
+              "atom1.0",
               "gnusocial",
               "pnut",
-              "pumpio"
+              "pumpio",
+              "rss2.0"
             ]
           }
         },
@@ -116,6 +118,7 @@
           "minItems": 0,
           "items": {
             "enum": [
+              "atom1.0",
               "blogger",
               "buddycloud",
               "diaspora",
@@ -136,6 +139,7 @@
               "posterous",
               "pumpio",
               "redmatrix",
+              "rss2.0",
               "smtp",
               "tent",
               "tumblr",

--- a/site/Rakefile
+++ b/site/Rakefile
@@ -12,7 +12,7 @@ rule(%r{^source/ns/schema/} => [
   cp t.source, t.name
 end
 
-task install_schemas: %w(source/ns/schema/1.0 source/ns/schema/1.1)
+task install_schemas: %w(source/ns/schema/1.0 source/ns/schema/1.1 source/ns/schema/2.0)
 
 file "source/protocol.html.md" => "../PROTOCOL.md" do |t|
   cp t.source, t.name

--- a/site/source/schema.html.slim
+++ b/site/source/schema.html.slim
@@ -1,3 +1,7 @@
+h1 NodeInfo 2.0
+
+script src="/docson/widget.js" data-schema="/ns/schema/2.0#" data-docson="/docson/index.html"
+
 h1 NodeInfo 1.1
 
 script src="/docson/widget.js" data-schema="/ns/schema/1.1#" data-docson="/docson/index.html"

--- a/tests/spec/nodeinfo_20_spec.rb
+++ b/tests/spec/nodeinfo_20_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe "NodeInfo schema 2.0" do
+  it "is a valid draft4 json schema" do
+    expect(schema_for("2.0")).to match_json_schema :json_schema_draft4
+  end
+
+  it "validates the example" do
+    expect(example_for("2.0")).to match_json_schema :nodeinfo_20
+  end
+end


### PR DESCRIPTION
I created a new version 2.0 and changed the following things:

#15: Make `software.name` free text (I didn't get much feedback to the issue, so I hope it's OK.)
#16: Use protocol names instead of software names (@annando I removed `friendica` and `gnusocial` and then added `dfrn` and `ostatus`. `zot` was already there, so I only removed `redmatrix`. I hope that is correct.)

That changes make NodeInfo more flexible for new projects, since they can support existing protocols without the need of a new NodeInfo-version. There can also be a fork of an existing software, and they can announce their new software name, but still support the same protocols.

The `software.name` should only be used as informational metadata (like `User-Agent` in http). When deciding if something is compatible, you should use `protocols` instead.