### PR TITLE
Add Hubzilla and GangGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Please see the [protocol definition](PROTOCOL.md).
 So far integration of this standard exist for the following softwares:
 
 * [diaspora*](https://diasporafoundation.org)
-* [Friendica](http://friendica.com/)
+* [Friendica](https://friendi.ca)
+* [Hubzilla](https://hubzilla.org)
+* [GangGo](https://ganggo.github.io)
 
 ## License
 


### PR DESCRIPTION
Both have a valid implementation of NodeInfo 2.0 now :tada: 

I also changed the link for Friendica, because that is the URL they have at GitHub and the old link was only a redirect to the new one.