### PR TITLE
Add Mobilizon to supported software

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ So far integration of this standard exist for the following softwares:
 * [GangGo](https://ganggo.github.io)
 * [Hubzilla](https://hubzilla.org)
 * [Misskey](https://misskey.xyz)
+* [Mobilizon](https://joinmobilizon.org/)
 * [MoodleNet](https://moodle.net)
 * [PeerTube](https://joinpeertube.org)
 * [Pixelfed](https://pixelfed.org)
 * [Pleroma](https://pleroma.social)
 * [WordPress](https://wordpress.org/plugins/nodeinfo/)
+
 
 ## License
 


### PR DESCRIPTION
Mobilizon 2.1.0 suppors nodeinfo 2.0, see for example the reference instance https://mobilizon.fr/.well-known/nodeinfo