### PR TITLE
add Owncast to list of software with nodeinfo integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ So far integration of this standard exist for the following softwares:
 * [Misskey](https://misskey.xyz)
 * [Mobilizon](https://joinmobilizon.org/)
 * [MoodleNet](https://moodle.net)
+* [Owncast](https://owncast.online)
 * [PeerTube](https://joinpeertube.org)
 * [Pixelfed](https://pixelfed.org)
 * [Pleroma](https://pleroma.social)


### PR DESCRIPTION
Owncast conforms to the standard scheme starting v0.0.12