### PR TITLE
add Mastodon to the support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ So far integration of this standard exist for the following softwares:
 * [GangGo](https://ganggo.github.io)
 * [Hubzilla](https://hubzilla.org)
 * [Lemmy](https://join-lemmy.org/)
+* [Mastodon](https://joinmastodon.org/)
 * [Misskey](https://misskey.xyz)
 * [Mobilizon](https://joinmobilizon.org/)
 * [MoodleNet](https://moodle.net)


### PR DESCRIPTION
starting from v4.0.0, Mastodon [conforms to NodeInfo 2.0](https://fedi.ninja/mastodon.social/nodeinfo)