### PR TITLE
add Gancio to list of software

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ So far integration of this standard exist for the following softwares:
 * [diaspora*](https://diasporafoundation.org)
 * [Friendica](https://friendi.ca)
 * [Funkwhale](https://funkwhale.audio)
+* [Gancio](https://gancio.org)
 * [GangGo](https://ganggo.github.io)
 * [Gitea](https://gitea.io)
 * [Hubzilla](https://hubzilla.org)


### PR DESCRIPTION
[Gancio](https://gancio.org) supports nodeinfo (2.0 and 2.1)

example https://gancio.cisti.org/.well-known/nodeinfo