### PR TITLE
Add new "instance" object and use it for instance name propagation

### DIFF
--- a/schemas/2.2/example.json
+++ b/schemas/2.2/example.json
@@ -1,5 +1,8 @@
 {
   "version": "2.2",
+  "instance": {
+    "name": "New FI𝑓F"
+  },
   "software": {
     "name": "diaspora",
     "version": "0.5.0",

--- a/schemas/2.2/schema.json
+++ b/schemas/2.2/schema.json
@@ -7,6 +7,7 @@
   "additionalProperties": false,
   "required": [
     "version",
+    "instance",
     "software",
     "protocols",
     "services",
@@ -20,6 +21,18 @@
       "enum": [
         "2.2"
       ]
+    },
+    "instance":{
+      "description": "Metadata specific to the instance. An instance is a the concrete installation of a software running on a server.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "If supported by the software the administrator configured name of this instance",
+          "type": "string",
+          "pattern": "^.{0,500}$"
+        }
+      }
     },
     "software": {
       "description": "Metadata about server software in use.",


### PR DESCRIPTION
move wily used [`nodeName`](https://codeberg.org/thefederationinfo/nodeinfo_metadata_survey) into the normal  spec.
this also should contain more instance configured specific information. 