### PR TITLE
Add description to instance

### DIFF
--- a/schemas/2.2/example.json
+++ b/schemas/2.2/example.json
@@ -1,7 +1,8 @@
 {
   "version": "2.2",
   "instance": {
-    "name": "New FI𝑓F"
+    "name": "FI𝑓F fediverse",
+    "description": "Welcome to the FI𝑓F fediverse server"
   },
   "software": {
     "name": "diaspora",

--- a/schemas/2.2/schema.json
+++ b/schemas/2.2/schema.json
@@ -31,6 +31,11 @@
           "description": "If supported by the software the administrator configured name of this instance",
           "type": "string",
           "pattern": "^.{0,500}$"
+        },
+        "description": {
+          "description": "If supported by the software the administrator configured long form description of this instance.",
+          "type": "string",
+          "pattern": "^.{0,5000}$"
         }
       }
     },


### PR DESCRIPTION
move wily used [`nodeDescription`](https://codeberg.org/thefederationinfo/nodeinfo_metadata_survey) into the normal  spec.
this also should contain more instance configured specific information. 