### PR TITLE
Add "activeWeek" to usage.users

### DIFF
--- a/schemas/2.2/example.json
+++ b/schemas/2.2/example.json
@@ -19,7 +19,8 @@
     "users": {
       "total": 123,
       "activeHalfyear": 42,
-      "activeMonth": 23
+      "activeMonth": 23,
+      "activeWeek": 22
     },
     "localPosts": 500,
     "localComments": 1000

--- a/schemas/2.2/schema.json
+++ b/schemas/2.2/schema.json
@@ -177,6 +177,11 @@
               "description": "The amount of users that signed in at least once in the last 30 days.",
               "type": "integer",
               "minimum": 0
+            },
+            "activeWeek": {
+              "description": "The amount of users that signed in at least once in the last 7 days.",
+              "type": "integer",
+              "minimum": 0
             }
           }
         },


### PR DESCRIPTION
Add optional activeWeek stats.
This allow to represent https://github.com/jaywink/nodeinfo2/blob/faed688e4e29e60cf5b08056436558ee2deccb26/schemas/1.0/schema.json#L119C28-L119C28