### PR TITLE
Add /kbin to list of supporting platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ So far, integration of this standard exists for the following software:
 * [GangGo](https://ganggo.github.io)
 * [Gitea](https://gitea.io)
 * [Hubzilla](https://hubzilla.org)
+* [/kbin](https://kbin.pub)
 * [Lemmy](https://join-lemmy.org)
 * [Mastodon](https://joinmastodon.org)
 * [Misskey](https://misskey-hub.net)


### PR DESCRIPTION
Includes the "/kbin" name styling (not dissimilar to "diaspora*" in using lowercase and a symbol)