### PR TITLE
Update 2.2 schema to support atprotocol protocol and record usage

### DIFF
--- a/schemas/2.2/schema.json
+++ b/schemas/2.2/schema.json
@@ -74,6 +74,7 @@
       "items": {
         "enum": [
           "activitypub",
+          "atprotocol",
           "buddycloud",
           "dfrn",
           "diaspora",
@@ -200,6 +201,19 @@
           "description": "The amount of comments that were made by users that are registered on this server.",
           "type": "integer",
           "minimum": 0
+        },
+        "records": {
+          "description": "statistics about the records created on this server by collection.",
+          "type": "object",
+          "minProperties": 0,
+          "additionalProperties": { "type": "integer", "minimum": 0 },
+          "properties": {
+            "app.bsky.feed.post": {
+              "description": "The total number of records in the app.bsky.feed.post collection.",
+              "type": "integer",
+              "minimum": 0
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
This PR introduces two changes to the 2.2 schema to support atprotocol nodes.

The `atprotocol` enum was introduced to allow [ATProtocol Data Repositories](https://atproto.com/guides/data-repos) to announce themselves using `GET /.well-known/nodeinfo`.

The `usage` structure was updated to include the `records` object which is a string to integer key/value pair object for reporting collection statistics. Within ATProtocol, [namespaced identifiers](https://atproto.com/specs/nsid) are used to identify collections of records. This structure allows personal data server (PDS) instances to self-report the number of records it contains across all repositories (account) across collections.