### PR TITLE
Add Mbin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ So far, integration of this standard exists for the following software:
 * [Lemmy](https://join-lemmy.org)
 * [Litecord](https://gitlab.com/litecord/litecord)
 * [Mastodon](https://joinmastodon.org)
+* [Mbin](https://github.com/MbinOrg/mbin)
 * [Misskey](https://misskey-hub.net)
 * [Mobilizon](https://joinmobilizon.org)
 * [MoodleNet](https://moodle.net)


### PR DESCRIPTION
[Mbin](https://github.com/MbinOrg/mbin) is missing from the list of software. This PR fixes that.