### PR TITLE
Suggest adding Emissary to the list of supporting servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ So far, integration of this standard exists for the following software:
 
 * [BookWyrm](https://joinbookwyrm.com)
 * [diaspora*](https://diasporafoundation.org)
+* [Emissary](https://emissary.dev)
 * [Friendica](https://friendi.ca)
 * [Funkwhale](https://funkwhale.audio)
 * [Gancio](https://gancio.org)


### PR DESCRIPTION
Emissary powers Bandwagon.fm, and AtlasMaps.org, with several other Fediverse applications in the works.  And NodeInfo is  an important part of the ActivityIntents implementation that I use.  Is it possible to include Emissary in this list of servers that support NodeInfo?